### PR TITLE
Added Mateo provider

### DIFF
--- a/.devcontainer/ha_config/sensors.yaml
+++ b/.devcontainer/ha_config/sensors.yaml
@@ -32,7 +32,9 @@
   name: skolmaten.se - StadaStadsskogen skola
   url: "  https://skolmaten.se/aktivitetshuset-stadsskogen-skola"
 
-
+- platform: skolmat
+  name: mateo.se - Kävlinge utbildning
+  url: "https://meny.mateo.se/kavlinge-utbildning/31"
 
 
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,8 @@ sensor:
   1. Open https://mpi.mashie.com/public/app and find your school by using the search box
   2. When you arrive at the page where you can see the menu, copy the url\
     Like: `https://mpi.mashie.com/public/app/Laholms%20kommun/a326a379`
+
+#### mateo.se ####
+  1. Open https://meny.mateo.se and find your school by using the search box
+  2. When you arrive at the page where you can see the menu, copy the url\
+    Like: `https://meny.mateo.se/kavlinge-utbildning/91`

--- a/test/test.py
+++ b/test/test.py
@@ -14,7 +14,8 @@ conf = {
     "matilda1": "https://menu.matildaplatform.com/meals/week/63fc6e2dccb95f5ce56d8ada_skolor",
     "matilda2": "https://menu.matildaplatform.com/meals/week/63fc8f84ccb95f5ce570a0d4_parkskolan-restaurang?startDate=2023-05-22&endDate=2023-05-28",
     "mashie": "https://mpi.mashie.com/public/app/Laholms%20kommun/a326a379",
-    "skolmaten2": "https://skolmaten.se/annerstaskolan"
+    "skolmaten2": "https://skolmaten.se/annerstaskolan",    
+    "mateo": "https://meny.mateo.se/kavlinge-utbildning/31"
 }
 
 menu = Menu.createMenu(asyncio.to_thread, url=conf["skolmaten"])


### PR DESCRIPTION
# Mateo.se

Added new provider, Mateo.se for skolmat integration.

Found out my kommun has changed their skolmat provider to Mateo.se recently.

Here is a PR to support that provider aswell.

It's a little bit different than the rest of the providers, since they get the data from a json-file stored in a bucket.
Currently it's stored at glesys, but I decided to implement a search in the js-content, to find the base-address, in case they switch their file provider in the future, to make the provider integration a bit more resilient to such scenarios.

Updated with a test-case aswell as the readme.