### PR TITLE
Prevent blank calendar events when Skolmaten returns empty menu data

### DIFF
--- a/custom_components/skolmat/calendar.py
+++ b/custom_components/skolmat/calendar.py
@@ -29,6 +29,10 @@ from .menu import Menu
 _LOGGER = logging.getLogger(__name__)
 
 
+def _has_event_content(summary: str | None, description: str | None) -> bool:
+    return bool((summary or "").strip() or (description or "").strip())
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, add_entities):
     data = hass.data[DOMAIN][entry.entry_id]
     menu: Menu = data["menu"]
@@ -150,8 +154,13 @@ class SkolmatCalendarEntity(CalendarEntity):
         # Add today's menu to history if needed
         summary = self._menu.getReadableDaySummary(today)
         menu_text = self._menu.getReadableDayMenu(today)
-        if self._history.get(today_str) != {"summary": summary, "menu": menu_text}:
-            self._history[today_str] = {"summary": summary, "menu": menu_text}
+        today_info = {"summary": summary, "menu": menu_text}
+        if _has_event_content(summary, menu_text):
+            if self._history.get(today_str) != today_info:
+                self._history[today_str] = today_info
+                self._history_dirty = True
+        elif self._history.get(today_str) == {"summary": "", "menu": ""}:
+            self._history.pop(today_str, None)
             self._history_dirty = True
 
         # Prune history older than N days
@@ -173,6 +182,8 @@ class SkolmatCalendarEntity(CalendarEntity):
             day_date = date.fromisoformat(d)
             if day_date < today:
                 description = info.get("menu") or self._menu.getReadableDayMenu(day_date)
+                if not _has_event_content(info.get("summary"), description):
+                    continue
                 events.append(
                     self._build_event(
                         day=day_date,
@@ -187,24 +198,34 @@ class SkolmatCalendarEntity(CalendarEntity):
             menu_dates.add(day_date)
             if day_date < today:
                 continue
+            summary = self._menu.getReadableDaySummary(day_date)
+            description = self._menu.getReadableDayMenu(day_date)
+            if not _has_event_content(summary, description):
+                continue
             events.append(
                 self._build_event(
                     day=day_date,
-                    summary=self._menu.getReadableDaySummary(day_date),
-                    description=self._menu.getReadableDayMenu(day_date),
+                    summary=summary,
+                    description=description,
                 )
             )
 
         if today not in menu_dates and today_str in self._history:
             info = self._history[today_str]
             description = info.get("menu") or menu_text
-            events.append(
-                self._build_event(
-                    day=today,
-                    summary=info.get("summary", ""),
-                    description=description,
+            if not _has_event_content(info.get("summary"), description):
+                self._history.pop(today_str, None)
+                self._history_dirty = True
+            else:
+                events.append(
+                    self._build_event(
+                        day=today,
+                        summary=info.get("summary", ""),
+                        description=description,
+                    )
                 )
-            )
+
+        await self._async_save_history()
 
         events.sort(key=lambda e: self._normalize(e.start))
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -342,3 +342,9 @@ Template:
 - Context: Limiting to the next N calendar dates could render fewer days than `rolling_week_max_days` when weekend/empty dates are in range.
 - Impact: Rolling-week now fills up to `rolling_week_max_days` with non-empty dates in chronological order, matching the expected behavior.
 - References: skolmat-card/skolmat-card.js
+
+- Date: 2026-03-26
+- Decision: Skip blank calendar history/event entries when a provider returns no usable menu text.
+- Context: Some `skolmaten.se` URLs return `WeekState: null`, which previously produced an empty but valid menu fetch and a blank calendar event for today.
+- Impact: Calendar history is only persisted when summary or description has content, stale blank history for today is pruned, and blank events are skipped.
+- References: custom_components/skolmat/calendar.py, test/tests/test_calendar_empty_menu.py

--- a/test/tests/test_calendar_empty_menu.py
+++ b/test/tests/test_calendar_empty_menu.py
@@ -1,0 +1,210 @@
+import asyncio
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CALENDAR_PATH = ROOT / "custom_components" / "skolmat" / "calendar.py"
+
+
+def _install_homeassistant_stubs() -> None:
+    if "homeassistant" in sys.modules:
+        return
+
+    homeassistant = types.ModuleType("homeassistant")
+    components = types.ModuleType("homeassistant.components")
+    calendar_mod = types.ModuleType("homeassistant.components.calendar")
+    core_mod = types.ModuleType("homeassistant.core")
+    config_entries_mod = types.ModuleType("homeassistant.config_entries")
+    helpers_mod = types.ModuleType("homeassistant.helpers")
+    entity_mod = types.ModuleType("homeassistant.helpers.entity")
+    aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    storage_mod = types.ModuleType("homeassistant.helpers.storage")
+    util_mod = types.ModuleType("homeassistant.util")
+    dt_mod = types.ModuleType("homeassistant.util.dt")
+
+    class CalendarEntity:
+        @property
+        def available(self):
+            return getattr(self, "_attr_available", True)
+
+        async def async_added_to_hass(self):
+            return None
+
+    @dataclass
+    class CalendarEvent:
+        summary: str
+        description: str
+        start: object
+        end: object
+
+    class HomeAssistant:
+        pass
+
+    class ConfigEntry:
+        pass
+
+    class DeviceInfo(dict):
+        pass
+
+    class Store:
+        def __init__(self, hass, version, key):
+            self.data = None
+
+        async def async_load(self):
+            return self.data
+
+        async def async_save(self, data):
+            self.data = data
+
+    def async_get_clientsession(hass):
+        return None
+
+    def start_of_local_day(day):
+        return datetime.combine(day, datetime.min.time())
+
+    def as_local(value):
+        return value
+
+    def now():
+        return datetime.now()
+
+    def slugify(value):
+        return value.lower().replace(" ", "-")
+
+    calendar_mod.CalendarEntity = CalendarEntity
+    calendar_mod.CalendarEvent = CalendarEvent
+    core_mod.HomeAssistant = HomeAssistant
+    config_entries_mod.ConfigEntry = ConfigEntry
+    entity_mod.DeviceInfo = DeviceInfo
+    aiohttp_client_mod.async_get_clientsession = async_get_clientsession
+    storage_mod.Store = Store
+    dt_mod.start_of_local_day = start_of_local_day
+    dt_mod.as_local = as_local
+    dt_mod.now = now
+    util_mod.slugify = slugify
+    util_mod.dt = dt_mod
+
+    sys.modules["homeassistant"] = homeassistant
+    sys.modules["homeassistant.components"] = components
+    sys.modules["homeassistant.components.calendar"] = calendar_mod
+    sys.modules["homeassistant.core"] = core_mod
+    sys.modules["homeassistant.config_entries"] = config_entries_mod
+    sys.modules["homeassistant.helpers"] = helpers_mod
+    sys.modules["homeassistant.helpers.entity"] = entity_mod
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_mod
+    sys.modules["homeassistant.helpers.storage"] = storage_mod
+    sys.modules["homeassistant.util"] = util_mod
+    sys.modules["homeassistant.util.dt"] = dt_mod
+
+
+def _load_calendar_entity():
+    _install_homeassistant_stubs()
+
+    custom_components = types.ModuleType("custom_components")
+    skolmat_pkg = types.ModuleType("custom_components.skolmat")
+    skolmat_pkg.__path__ = [str(CALENDAR_PATH.parent)]
+
+    const_mod = types.ModuleType("custom_components.skolmat.const")
+    const_mod.DOMAIN = "skolmat"
+    const_mod.CONF_NAME = "name"
+    const_mod.CONF_URL = "url"
+    const_mod.CONF_PROVIDER = "provider"
+    const_mod.CONF_LUNCH_BEGIN = "lunch_begin"
+    const_mod.CONF_LUNCH_END = "lunch_end"
+    const_mod.CALENDAR_HISTORY_DAYS = 90
+
+    menu_mod = types.ModuleType("custom_components.skolmat.menu")
+
+    class Menu:
+        pass
+
+    menu_mod.Menu = Menu
+
+    sys.modules["custom_components"] = custom_components
+    sys.modules["custom_components.skolmat"] = skolmat_pkg
+    sys.modules["custom_components.skolmat.const"] = const_mod
+    sys.modules["custom_components.skolmat.menu"] = menu_mod
+
+    spec = importlib.util.spec_from_file_location(
+        "custom_components.skolmat.calendar",
+        CALENDAR_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["custom_components.skolmat.calendar"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.SkolmatCalendarEntity
+
+
+SkolmatCalendarEntity = _load_calendar_entity()
+
+
+class FakeMenu:
+    provider = "skolmaten.se"
+
+    def __init__(self, menu_data, summaries=None, menus=None):
+        self.menu_data = menu_data
+        self.summaries = summaries or {}
+        self.menus = menus or {}
+
+    async def getMenu(self, session):
+        return self.menu_data
+
+    def getReadableDaySummary(self, day):
+        key = day.isoformat() if hasattr(day, "isoformat") else str(day)
+        return self.summaries.get(key, "")
+
+    def getReadableDayMenu(self, day):
+        key = day.isoformat() if hasattr(day, "isoformat") else str(day)
+        return self.menus.get(key, "")
+
+
+class FakeEntry:
+    entry_id = "entry-1"
+    data = {
+        "name": "Restaurang Rosengarden",
+        "url": "https://skolmaten.se/restaurang-rosengarden",
+        "provider": "skolmaten.se",
+    }
+
+
+def _make_entity(menu):
+    return SkolmatCalendarEntity(
+        hass=object(),
+        entry=FakeEntry(),
+        menu=menu,
+        url_hash="hash",
+    )
+
+
+def test_empty_menu_does_not_create_blank_event_for_today():
+    entity = _make_entity(FakeMenu(menu_data={}))
+
+    asyncio.run(entity.async_update())
+
+    assert entity._events == []
+    assert entity.event is None
+    assert entity._history == {}
+
+
+def test_empty_today_history_entry_is_pruned_when_menu_is_blank():
+    entity = _make_entity(FakeMenu(menu_data={}))
+    today = date.today().isoformat()
+    entity._history = {today: {"summary": "", "menu": ""}}
+
+    asyncio.run(entity.async_update())
+
+    assert today not in entity._history
+    assert entity._events == []
+    assert entity.event is None
+
+
+if __name__ == "__main__":
+    test_empty_menu_does_not_create_blank_event_for_today()
+    test_empty_today_history_entry_is_pruned_when_menu_is_blank()
+    print("test_calendar_empty_menu: ok")


### PR DESCRIPTION
Some `skolmaten.se` sources can return no usable week data, for example `https://skolmaten.se/restaurang-rosengarden` where the API returns `WeekState: null`.

Before this change, the integration treated that as a valid but empty menu and still created a blank calendar event for today. That in turn could crash calendar cards expecting a real event payload.

This change makes the calendar entity skip events with no summary and no description, and avoids persisting blank history entries for today.

Verified locally in Home Assistant with `https://skolmaten.se/restaurang-rosengarden`:
- the blank calendar event disappeared
- the affected calendar card no longer crashed